### PR TITLE
fix: publish dist/ so the package has an entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "minipass": "^7.1.3"
   },
   "files": [
-    "index.js"
+    "dist"
   ],
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
The current pack doesn't ship the code after the migration to tshy